### PR TITLE
Exceptions rescue

### DIFF
--- a/app/controllers/api/v1/books_controller.rb
+++ b/app/controllers/api/v1/books_controller.rb
@@ -3,6 +3,7 @@ module Api
     class BooksController < ApplicationController
       def index
         render json: serialized_books
+        rescue StandardError
       end
 
       private

--- a/app/controllers/api/v1/books_controller.rb
+++ b/app/controllers/api/v1/books_controller.rb
@@ -3,7 +3,8 @@ module Api
     class BooksController < ApplicationController
       def index
         render json: serialized_books
-        rescue StandardError
+      rescue StandardError
+        render json: {}, status: :internal_server_error
       end
 
       private

--- a/spec/controllers/books_controller/index_spec.rb
+++ b/spec/controllers/books_controller/index_spec.rb
@@ -41,15 +41,21 @@ RSpec.describe 'API V1 Books', type: :request do
       expect(json[:data].size).to eq(2)
     end
 
-    context "it is not successful" do
-      it 'returns an empty array when there are no books' do
+    context "No books" do
+      before do
         Book.destroy_all
+      end
+      it 'returns an empty array when there are no books' do
         get api_v1_books_path
         expect(json[:data]).to be_empty
       end
+    end
 
-      it 'returns a StandardError' do
+    context "Failure" do
+      before do
         allow(BookSerializer).to receive(:serialize).and_raise(StandardError)
+      end
+      it 'it returns http success' do
         get api_v1_books_path
         expect { response }.to raise_error
       end

--- a/spec/controllers/books_controller/index_spec.rb
+++ b/spec/controllers/books_controller/index_spec.rb
@@ -55,9 +55,9 @@ RSpec.describe 'API V1 Books', type: :request do
       before do
         allow(BookSerializer).to receive(:serialize).and_raise(StandardError)
       end
-      it 'it returns http success' do
+      it 'it returns a 500 error' do
         get api_v1_books_path
-        expect { response }.to raise_error
+        expect(response.status).to eq(500)
       end
     end
   end

--- a/spec/controllers/books_controller/index_spec.rb
+++ b/spec/controllers/books_controller/index_spec.rb
@@ -29,12 +29,6 @@ RSpec.describe 'API V1 Books', type: :request do
       })
     end
 
-    it 'returns an empty array when there are no books' do
-      Book.destroy_all
-      get api_v1_books_path
-      expect(json[:data]).to be_empty
-    end
-
     it 'returns all books in the response' do
       Book.create(
         author_name: 'George R.R. Martin',
@@ -45,6 +39,20 @@ RSpec.describe 'API V1 Books', type: :request do
       )
       get api_v1_books_path
       expect(json[:data].size).to eq(2)
+    end
+
+    context "it is not successful" do
+      it 'returns an empty array when there are no books' do
+        Book.destroy_all
+        get api_v1_books_path
+        expect(json[:data]).to be_empty
+      end
+
+      it 'returns a StandardError' do
+        allow(BookSerializer).to receive(:serialize).and_raise(StandardError)
+        get api_v1_books_path
+        expect { response }.to raise_error
+      end
     end
   end
 end


### PR DESCRIPTION
- When the serializer does not return a JSON string but, instead raises an exception. 
- Amended the controller to rescue the error. 
- Returns a 500 response. 